### PR TITLE
Немного изменил README и добавил функционал

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There is also a symmetrical task, `rake db:restore`, which restores the database
 
 Rails 3: add `gem rails_db_dump` to your Gemfile.
 
-Rails 2.3: add the gem to your environment, then add `include 'rails_db_dump/tasks'` to your Rakefile
+Rails 2.3: add the gem to your environment, then add `require 'rails_db_dump/tasks'` to your Rakefile
 
 ## Requirements
 

--- a/lib/rails_db_dump/tasks.rb
+++ b/lib/rails_db_dump/tasks.rb
@@ -2,7 +2,8 @@ namespace :db do
   desc "Dump the database to standard output. Pass a TABLE_NAME environment variable to dump a single table"
   task :dump do
     require 'yaml'
-    config = YAML.load_file(File.join(Rails.root,'config','database.yml'))[Rails.env]
+    db_config, env = YAML.load_file(File.join(Rails.root,'config','database.yml')), Rails.env
+    while (config = db_config[env]).is_a?(String) do; env = config; end
     table_name = ENV['TABLE_NAME']
 
     case config["adapter"]


### PR DESCRIPTION
- В README написано было что для поддержки в Rails 2.3+ нужно прописать `include 'rails_db_dump/tasks'` но это выдает ошибку, работает если написать `require 'rails_db_dump/tasks'`
- Добавил поддержку такого варианта когда в определенной секции `config/database.yml` указана ссылка на другой раздел, т.е. дублируют друг друга, например у меня:
  <pre>
  development:
  production

test:
  adapter: sqlite3
  database: db/test.sqlite3
  pool: 5
  timeout: 5000

production:
  adapter: mysql
  encoding: utf8
  database: dbname
  username: user
  password: secret
</pre>
теперь файл нормально будет обрабатываться при `RAILS_ENV=development` раньше выдавал ошибку
